### PR TITLE
SOLOLINK: Robust FW upload, ChibiOS compatibility, new uploader.py

### DIFF
--- a/flightcode/python/pixhawk.py
+++ b/flightcode/python/pixhawk.py
@@ -61,10 +61,10 @@ def glob_file(pattern):
 
 # /dev/serial/by-id/usb-3D_Robotics_PX4_FMU_v2.x_0-if00
 # /dev/serial/by-id/usb-3D_Robotics_PX4_BL_FMU_v2.x_0-if00
-dev_pattern_usb = "/dev/serial/by-id/usb-3D_Robotics*"
+dev_pattern_usb = "/dev/serial/by-id/usb*"
 
 # return device name or None
-def create_usb_serial(timeout=2):
+def create_usb_serial(timeout=5):
     usb.init()
     usb.enable()
     start_us = clock.gettime_us(clock.CLOCK_MONOTONIC)

--- a/flightcode/python/pixhawk.py
+++ b/flightcode/python/pixhawk.py
@@ -76,10 +76,10 @@ def create_usb_serial(timeout=5):
     end_us = clock.gettime_us(clock.CLOCK_MONOTONIC)
     dev_name = glob_file(dev_pattern_usb)
     if os.path.exists(dev_name):
-        logger.debug("%s created in %0.3f sec",
+        logger.info("%s created in %0.3f sec",
                      dev_name, (end_us - start_us) / 1000000.0)
     else:
-        logger.error("creating %s", dev_pattern_usb)
+        logger.info("creating %s", dev_pattern_usb)
         usb.disable()
         usb.uninit()
     return dev_name

--- a/flightcode/python/pixhawk.py
+++ b/flightcode/python/pixhawk.py
@@ -70,6 +70,7 @@ def create_usb_serial(timeout=5):
     start_us = clock.gettime_us(clock.CLOCK_MONOTONIC)
     now_us = start_us
     timeout_us = timeout * 1000000
+    
     while glob_file(dev_pattern_usb) is None and (now_us - start_us) < timeout_us:
         now_us = clock.gettime_us(clock.CLOCK_MONOTONIC)
         time.sleep(0.001)
@@ -79,7 +80,7 @@ def create_usb_serial(timeout=5):
         logger.info("%s created in %0.3f sec",
                      dev_name, (end_us - start_us) / 1000000.0)
     else:
-        logger.info("creating %s", dev_pattern_usb)
+        logger.info("error creating %s", dev_pattern_usb)
         usb.disable()
         usb.uninit()
     return dev_name
@@ -501,7 +502,7 @@ def removeFWfiles(dir):
     elif dir == 'green':
         filelist=glob.glob('/firmware/green/*.*')
     elif dir == 'main':
-        filelist=glob.glob('/firmware/*.px4')
+        filelist=glob.glob('/firmware/*.px4') + glob.glob('/firmware/*.apj')
     for file in filelist:
         os.remove(file)
 
@@ -663,7 +664,7 @@ def verify_usb():
 # full_path is the full path to the file, or None if no file
 # if full_path is not None, versions is a dictionary of version info
 def find_firmware(dir):
-    files = glob.glob("%s/*.px4" % dir)
+    files = glob.glob("%s/*.apj" % dir) + glob.glob("%s/*.px4" % dir)
     if len(files) == 0:
         return (None, None)
     # read git hashes
@@ -824,7 +825,7 @@ def initialize():
     elif os.path.exists("/log/.factory") and (baud is not None) and verify_usb():
         logger.info("pixhawk: factory - not loading firmware")
     else:
-        print "pixhawk: loading firmware"
+        print "pixhawk: loading firmware %s:", firmware_path
         logger.info("%s:", firmware_path)
         for v in firmware_version:
             logger.info("%-20s %s", v, firmware_version[v])

--- a/flightcode/python/pixhawk.py
+++ b/flightcode/python/pixhawk.py
@@ -516,7 +516,7 @@ def load(firmware_path):
 
     # load firmware
     start_us = clock.gettime_us(clock.CLOCK_MONOTONIC)
-    uploader = subprocess.Popen(["px_uploader.py",
+    uploader = subprocess.Popen(["uploader.py",
                            "--port=%s" % dev_pattern_usb,
                            firmware_path])
 

--- a/px_uploader/px_uploader.py
+++ b/px_uploader/px_uploader.py
@@ -663,7 +663,7 @@ def main():
                 try:
                     if "linux" in _platform:
                         # Linux, don't open Mac OS and Win ports
-                        if "COM" not in port and "tty.usb" not in port:
+                        if "tty.usb" not in port:
                             up = uploader(port, args.baud_bootloader, baud_flightstack, args.baud_bootloader_flash)
                     elif "darwin" in _platform:
                         # OS X, don't open Windows and Linux ports

--- a/px_uploader/px_uploader.py
+++ b/px_uploader/px_uploader.py
@@ -657,7 +657,7 @@ def main():
 
             for port in portlist:
 
-                # print("Trying %s" % port)
+                print("Trying %s" % port)
 
                 # create an uploader attached to the port
                 try:
@@ -713,21 +713,15 @@ def main():
                 try:
                     # ok, we have a bootloader, try flashing it
                     up.upload(fw, force=args.force, boot_delay=args.boot_delay)
+                    print("Loaded firmware. Closing port and exiting px_uploader.")
+                    up.close()      # Close the USB port
+                    sys.exit(0)     # Exit with zero due to success
 
-                except RuntimeError as ex:
-                    # print the error
-                    print("\nERROR: %s" % ex.args)
+                except Exception as e:
+                    print("\nERROR: %s; Closing port and exiting px_uploader" % e)
+                    up.close()      # Close the USB port
+                    sys.exit(1)     # Exit with non-zero due to error
 
-                except IOError:
-                    up.close()
-                    continue
-
-                finally:
-                    # always close the port
-                    up.close()
-
-                # we could loop here if we wanted to wait for more boards...
-                sys.exit(0)
 
             # Delay retries to < 20 Hz to prevent spin-lock from hogging the CPU
             time.sleep(0.05)

--- a/px_uploader/uploader.py
+++ b/px_uploader/uploader.py
@@ -67,15 +67,24 @@ import os
 
 from sys import platform as _platform
 
+# default list of port names to look for autopilots
+default_ports = [ '/dev/serial/by-id/usb-Ardu*',
+                  '/dev/serial/by-id/usb-3D*',
+                  '/dev/serial/by-id/usb-APM*',
+                  '/dev/serial/by-id/usb-Radio*',
+                  '/dev/serial/by-id/usb-*_3DR_*',
+                  '/dev/serial/by-id/usb-Hex_Technology_Limited*',
+                  '/dev/serial/by-id/usb-Hex_ProfiCNC*',
+                  '/dev/tty.usbmodem*']
+
+if "cygwin" in _platform:
+    default_ports += [ '/dev/ttyS*' ]
+    
 # Detect python version
 if sys.version_info[0] < 3:
     runningPython3 = False
 else:
     runningPython3 = True
-
-# list of tuples (bootloader boardID, firmware boardID, boardname)
-# designating firmware builds compatible with multiple boardIDs
-compatible_IDs = [(33, 9, 'AUAVX2.1')]
 
 class firmware(object):
     '''Loads a firmware file'''
@@ -196,7 +205,7 @@ class uploader(object):
 
     def __init__(self, portname, baudrate_bootloader, baudrate_flightstack, baudrate_bootloader_flash=None):
         # open the port, keep the default timeout short so we can poll quickly
-        self.port = serial.Serial(portname, baudrate_bootloader, timeout=0.5)
+        self.port = serial.Serial(portname, baudrate_bootloader, timeout=1.0)
         self.otp = b''
         self.sn = b''
         self.baudrate_bootloader = baudrate_bootloader
@@ -349,14 +358,14 @@ class uploader(object):
         self.__send(uploader.CHIP_ERASE +
                     uploader.EOC)
 
-        # erase is very slow, give it 30s
-        deadline = time.time() + 30.0
+        # erase is very slow, give it 20s
+        deadline = time.time() + 20.0
         while time.time() < deadline:
 
             # Draw progress bar (erase usually takes about 9 seconds to complete)
             estimatedTimeRemaining = deadline-time.time()
             if estimatedTimeRemaining >= 9.0:
-                self.__drawProgressBar(label, 30.0-estimatedTimeRemaining, 9.0)
+                self.__drawProgressBar(label, 20.0-estimatedTimeRemaining, 9.0)
             else:
                 self.__drawProgressBar(label, 10.0, 10.0)
                 sys.stdout.write(" (timeout: %d seconds) " % int(deadline-time.time()))
@@ -483,7 +492,7 @@ class uploader(object):
         # get the bootloader protocol ID first
         self.bl_rev = self.__getInfo(uploader.INFO_BL_REV)
         if (self.bl_rev < uploader.BL_REV_MIN) or (self.bl_rev > uploader.BL_REV_MAX):
-            print("Unsupported bootloader protocol %d" % uploader.INFO_BL_REV)
+            print("[uploader.py] Unsupported bootloader protocol %d" % uploader.INFO_BL_REV)
             raise RuntimeError("Bootloader protocol mismatch")
 
         self.board_type = self.__getInfo(uploader.INFO_BOARD_ID)
@@ -494,24 +503,13 @@ class uploader(object):
     def upload(self, fw, force=False, boot_delay=None):
         # Make sure we are doing the right thing
         if self.board_type != fw.property('board_id'):
-            # ID mismatch: check compatibility
-            incomp = True
-            for entry in compatible_IDs:
-                if (entry[0] == self.board_type) and (entry[1] == fw.property('board_id')):
-                     msg = "Target %s (board_id: %d) is compatible with firmware for board_id=%u)" % (
-                         entry[2], self.board_type, fw.property('board_id'))
-                     print("INFO: %s" % msg)
-                     incomp = False
-                     break
-            if incomp:                        
-                msg = "Firmware not suitable for this board (board_type=%u board_id=%u)" % (
-                    self.board_type, fw.property('board_id'))
-                print("WARNING: %s" % msg)
-                
-                if force:
-                    print("FORCED WRITE, FLASHING ANYWAY!")
-                else:
-                    raise IOError(msg)
+            msg = "Firmware not suitable for this board (board_type=%u board_id=%u)" % (
+                self.board_type, fw.property('board_id'))
+            print("WARNING: %s" % msg)
+            if force:
+                print("FORCED WRITE, FLASHING ANYWAY!")
+            else:
+                raise IOError(msg)
         if self.fw_maxsize < fw.property('image_size'):
             raise RuntimeError("Firmware image is too large for this board")
 
@@ -574,14 +572,14 @@ class uploader(object):
         self.port.close()
 
     def __next_baud_flightstack(self):
-        if self.baudrate_flightstack_idx + 1 >= len(self.baudrate_flightstack):
+        self.baudrate_flightstack_idx = self.baudrate_flightstack_idx + 1
+        if self.baudrate_flightstack_idx >= len(self.baudrate_flightstack):
             return False
+
         try:
-            self.port.baudrate = self.baudrate_flightstack[self.baudrate_flightstack_idx + 1]
-            self.baudrate_flightstack_idx = self.baudrate_flightstack_idx + 1
-        except serial.SerialException:
-            # Sometimes _configure_port fails
-            time.sleep(0.04)
+            self.port.baudrate = self.baudrate_flightstack[self.baudrate_flightstack_idx]
+        except Exception:
+            return False
 
         return True
 
@@ -618,7 +616,8 @@ def main():
 
     # Parse commandline arguments
     parser = argparse.ArgumentParser(description="Firmware uploader for the PX autopilot system.")
-    parser.add_argument('--port', action="store", required=True, help="Comma-separated list of serial port(s) to which the FMU may be attached")
+    parser.add_argument('--port', action="store", help="Comma-separated list of serial port(s) to which the FMU may be attached",
+                        default=None)
     parser.add_argument('--baud-bootloader', action="store", type=int, default=115200, help="Baud rate of the serial port (default is 115200) when communicating with bootloader, only required for true serial ports.")
     parser.add_argument('--baud-bootloader-flash', action="store", type=int, default=None, help="Attempt to negotiate this baudrate with bootloader for flashing.")
     parser.add_argument('--baud-flightstack', action="store", default="57600", help="Comma-separated list of baud rate of the serial port (default is 57600) when communicating with flight stack (Mavlink or NSH), only required for true serial ports.")
@@ -635,18 +634,22 @@ def main():
 
     # Load the firmware file
     fw = firmware(args.firmware)
-    print("Loaded firmware for %x,%x, size: %d bytes, waiting for the bootloader..." % (fw.property('board_id'), fw.property('board_revision'), fw.property('image_size')))
-    print("If the board does not respond within 1-2 seconds, unplug and re-plug the USB connector.")
+    print("[uploader.py] Loaded firmware for %x,%x, size: %d bytes, waiting for the bootloader..." % (fw.property('board_id'), fw.property('board_revision'), fw.property('image_size')))
+    print("[uploader.py] If the board does not respond within 1-2 seconds, unplug and re-plug the USB connector.")
 
     # Spin waiting for a device to show up
+    upload_success = False
     try:
         while True:
             portlist = []
-            patterns = args.port.split(",")
+            if args.port is None:
+                patterns = default_ports
+            else:
+                patterns = args.port.split(",")
             # on unix-like platforms use glob to support wildcard ports. This allows
             # the use of /dev/serial/by-id/usb-3D_Robotics on Linux, which prevents the upload from
             # causing modem hangups etc
-            if "linux" in _platform or "darwin" in _platform:
+            if "linux" in _platform or "darwin" in _platform or "cygwin" in _platform:
                 import glob
                 for pattern in patterns:
                     portlist += glob.glob(pattern)
@@ -657,18 +660,20 @@ def main():
 
             for port in portlist:
 
-                print("Trying %s" % port)
+                print("[uploader.py] Trying %s" % port)
 
                 # create an uploader attached to the port
                 try:
                     if "linux" in _platform:
                         # Linux, don't open Mac OS and Win ports
-                        if "tty.usb" not in port:
-                            up = uploader(port, args.baud_bootloader, baud_flightstack, args.baud_bootloader_flash)
+                        up = uploader(port, args.baud_bootloader, baud_flightstack, args.baud_bootloader_flash)
                     elif "darwin" in _platform:
                         # OS X, don't open Windows and Linux ports
                         if "COM" not in port and "ACM" not in port:
                             up = uploader(port, args.baud_bootloader, baud_flightstack, args.baud_bootloader_flash)
+                    elif "cygwin" in _platform:
+                        # Cygwin, don't open MAC OS and Win ports, we are more like Linux. Cygwin needs to be before Windows test
+                        up = uploader(port, args.baud_bootloader, baud_flightstack, args.baud_bootloader_flash)
                     elif "win" in _platform:
                         # Windows, don't open POSIX ports
                         if "/" not in port:
@@ -680,6 +685,7 @@ def main():
                     # and loop to the next port
                     continue
 
+                print("[uploader.py] Looking for bootloader on %s" % (port))
                 found_bootloader = False
                 while (True):
                     up.open()
@@ -689,7 +695,7 @@ def main():
                         # identify the bootloader
                         up.identify()
                         found_bootloader = True
-                        print("Found board %x,%x bootloader rev %x on %s" % (up.board_type, up.board_rev, up.bl_rev, port))
+                        print("[uploader.py] Found board %x,%x bootloader rev %x on %s" % (up.board_type, up.board_rev, up.bl_rev, port))
                         break
 
                     except Exception:
@@ -713,22 +719,36 @@ def main():
                 try:
                     # ok, we have a bootloader, try flashing it
                     up.upload(fw, force=args.force, boot_delay=args.boot_delay)
-                    print("Loaded firmware. Closing port and exiting px_uploader.")
-                    up.close()      # Close the USB port
-                    sys.exit(0)     # Exit with zero due to success
+                    [uploader.py] 
+                    upload_success = True
 
-                except Exception as e:
-                    print("\nERROR: %s; Closing port and exiting px_uploader" % e)
-                    up.close()      # Close the USB port
-                    sys.exit(1)     # Exit with non-zero due to error
+                except RuntimeError as ex:
+                    # print the error
+                    print("[uploader.py] \nERROR: %s" % ex.args)
 
+                except IOError:
+                    up.close()
+                    continue
+
+                finally:
+                    # always close the port
+                    up.close()
+
+            # If successfully uploaded, exit with 0
+            # If failed, exit with non-zero so calling scripts are aware it failed
+            if upload_success:
+                print "[uploader.py] Exiting with success"
+                sys.exit(0)     # Exit with zero for success
+            else:
+                print "[uploader.py] Exiting with error"
+                sys.exit(1)     # Exit with non-zero due to error
 
             # Delay retries to < 20 Hz to prevent spin-lock from hogging the CPU
             time.sleep(0.05)
 
     # CTRL+C aborts the upload/spin-lock by interrupt mechanics
     except KeyboardInterrupt:
-        print("\n Upload aborted by user.")
+        print("\n [uploader.py] Upload aborted by user.")
         sys.exit(0)
 
 if __name__ == '__main__':


### PR DESCRIPTION
These changes all revolve around compatibility loading modern ArduPilot firmware.  In the last year, ArduPilot has moved away from the old px4 related stuff and moved on to a new RTOS called ChibiOS.  There were also some outstanding error handling issues to correct from back in the day.  Short summary:

- Add compatibility for new ArduPilot firmware file type (`*.apj`).  Will still load older `*.px4` files too.
- Added error handling to ArduPilot FW loading scripts.  Firmware failing to load will delete itself to prevent Solo from being stuck in a never ending loop you can't escape without factory resetting
- Add compatibility for new ArduPilot ChibiOS RTOS that replaces nuttx.  Changes USB device ID and some other bits
- Replace old `px_uploader.py` with the new ArduPilot `uploader.py`.  
- Misc boot logging enhancements for easier troubleshooting